### PR TITLE
Fix MTU size.

### DIFF
--- a/webbluetooth/micropython/repl/index.html
+++ b/webbluetooth/micropython/repl/index.html
@@ -95,6 +95,7 @@ div.terminal-output div div, .cmd {
 const bleNusServiceUUID  = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 const bleNusCharRXUUID   = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 const bleNusCharTXUUID   = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
+const MTU = 20;
 
 var term;
 var bleDevice;
@@ -175,14 +176,23 @@ function inject_text(text) {
 
 function sendString(s) {
     log("send" + s);
-    let arrayLength = s.length;
-    let val_arr = new Uint8Array(arrayLength + 1)
-    for (let i = 0; i < arrayLength; i++) {
+    let val_arr = new Uint8Array(s.length + 1)
+    for (let i = 0; i < s.length; i++) {
         let val = s[i].charCodeAt(0);
         val_arr[i] = val;
     }
-    val_arr[arrayLength] = 13;
-    rxCharacteristic.writeValue(val_arr);
+    val_arr[s.length] = 13;
+    sendNextChunk(val_arr);
+}
+
+function sendNextChunk(a) {
+  let chunk = a.slice(0, MTU);
+  rxCharacteristic.writeValue(chunk)
+    .then(function() {
+      if (a.length > MTU) {
+        sendNextChunk(a.slice(MTU));
+      }
+    });
 }
 
 function handleError(error) {


### PR DESCRIPTION
Many BLE devices can only handle 20 bytes per characteristic read/write. Some can handle more, but detecting this does not seem to be implemented (yet?).

See:
https://github.com/WebBluetoothCG/web-bluetooth/issues/284

fixes https://github.com/tralamazza/micropython/issues/108